### PR TITLE
Download newspost images in parallel

### DIFF
--- a/.changeset/fuzzy-planes-crash.md
+++ b/.changeset/fuzzy-planes-crash.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix image extensions when downloading images

--- a/.changeset/khaki-pots-approve.md
+++ b/.changeset/khaki-pots-approve.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Add info logging to newspost scraper

--- a/.changeset/loud-eyes-travel.md
+++ b/.changeset/loud-eyes-travel.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Download newspost images in parallel

--- a/src/scrapers/news/news.ts
+++ b/src/scrapers/news/news.ts
@@ -30,11 +30,13 @@ const news: ScrapingService<MediaWikiBuilder> = {
         await newsContent.format(results.content, page.url(), results.title)
       );
 
+      console.info("Writing newspost results to file...");
       try {
         await fs.writeFileSync(
           `out/news/${formatFileName(results.title)}/newspost.txt`,
           builder.build()
         );
+        console.info("Successfully created newspost.txt");
       } catch (err) {
         console.error(err);
       }

--- a/src/scrapers/news/sections/newsContent/nodes/image.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/image.ts
@@ -27,7 +27,9 @@ export const imageParser: ContentNodeParser = (node, { title, center }) => {
 
     const imageName = `${formattedTitle} (${++ContentContext.imageCount})`;
     const imageExtension = getImageExtension(imageLink);
-    const dimensions = sizeOf(`${imageDirectory}/${imageName}.png`);
+    const dimensions = sizeOf(
+      `${imageDirectory}/${imageName}.${imageExtension}`
+    );
 
     return new MediaWikiFile(`${imageName}.${imageExtension}`, {
       resizing: { width: dimensions.width > 600 ? 600 : dimensions.width },

--- a/src/scrapers/news/sections/newsHeader.ts
+++ b/src/scrapers/news/sections/newsHeader.ts
@@ -2,7 +2,11 @@ import fs from "fs";
 import { parse } from "node-html-parser";
 
 import { NewsSection } from "./types";
-import { downloadImage, formatFileName } from "../../../utils/images";
+import {
+  downloadImage,
+  formatFileName,
+  getImageExtension,
+} from "../../../utils/images";
 import {
   MediaWikiBreak,
   MediaWikiContent,
@@ -25,10 +29,12 @@ const newsHeader: NewsSection = {
       fs.mkdirSync(newsDirectory, { recursive: true });
     }
 
-    const newspostImageName = `${formattedTitle} newspost`;
+    const newspostImageName = `${formattedTitle} newspost.${getImageExtension(
+      image.attributes.src
+    )}`;
     downloadImage(
       image.attributes.src,
-      `${newsDirectory}/${newspostImageName}.png`
+      `${newsDirectory}/${newspostImageName}`
     );
 
     const content: MediaWikiContent[] = [];
@@ -42,7 +48,7 @@ const newsHeader: NewsSection = {
     );
     content.push(new MediaWikiBreak());
     content.push(
-      new MediaWikiFile(`${newspostImageName}.png`, {
+      new MediaWikiFile(newspostImageName, {
         horizontalAlignment: "right",
       })
     );

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -9,6 +9,7 @@ import path from "path";
  * @returns
  */
 export const downloadImage = async (url: string, filepath: string) => {
+  console.info(`Attempting image download: ${url}`);
   return new Promise((resolve, reject) => {
     client.get(url, (res) => {
       if (res.statusCode === 200) {
@@ -16,6 +17,7 @@ export const downloadImage = async (url: string, filepath: string) => {
           .pipe(fs.createWriteStream(filepath))
           .on("error", reject)
           .once("close", () => resolve(filepath));
+        console.info(`Downloaded image ${filepath}`);
       } else {
         res.resume();
         reject(


### PR DESCRIPTION
**Description**

- Download newspost images in parallel
- Add info logging to newspost scraper
- Fix newspost image file extensions