### PR TITLE
[#21] Fix separator missing from news post footer

### DIFF
--- a/.changeset/fresh-rocks-bow.md
+++ b/.changeset/fresh-rocks-bow.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Add support for content transformers

--- a/.changeset/red-mirrors-wash.md
+++ b/.changeset/red-mirrors-wash.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix missing seperator in news post footer

--- a/.changeset/strong-tips-mix.md
+++ b/.changeset/strong-tips-mix.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Add test for mediawiki link

--- a/src/scrapers/news/news.ts
+++ b/src/scrapers/news/news.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 
 import { newsContent, newsHeader } from "./sections";
+import { NewsFooterTransformer } from "./transformers";
 import { formatFileName } from "../../utils/images";
 import { MediaWikiBuilder } from "../../utils/mediawiki";
 import { ScrapingService } from "../types";
@@ -23,12 +24,14 @@ const news: ScrapingService<MediaWikiBuilder> = {
       });
 
       const builder = new MediaWikiBuilder();
-      builder.addContents(
-        await newsHeader.format(results.header, page.url(), results.title)
-      );
-      builder.addContents(
-        await newsContent.format(results.content, page.url(), results.title)
-      );
+      builder
+        .addContents(
+          await newsHeader.format(results.header, page.url(), results.title)
+        )
+        .addContents(
+          await newsContent.format(results.content, page.url(), results.title)
+        )
+        .addTransformer(new NewsFooterTransformer());
 
       console.info("Writing newspost results to file...");
       try {

--- a/src/scrapers/news/transformers/__tests__/__snapshots__/footerTransformer.test.ts.snap
+++ b/src/scrapers/news/transformers/__tests__/__snapshots__/footerTransformer.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewsFooterTransformer should insert the separator in front of oldschool team section 1`] = `
+"__TOC__
+
+[[test|test]]
+'''test'''
+----
+
+''The Old School Team.''"
+`;
+
+exports[`NewsFooterTransformer should insert the separator in front of social media discussion section 1`] = `
+"__TOC__
+
+[[test|test]]
+'''test'''
+----
+
+You can also discuss this update on our
+'''Mods test, test and test'''
+''The Old School Team.''"
+`;

--- a/src/scrapers/news/transformers/__tests__/footerTransformer.test.ts
+++ b/src/scrapers/news/transformers/__tests__/footerTransformer.test.ts
@@ -1,0 +1,47 @@
+import {
+  MediaWikiBreak,
+  MediaWikiBuilder,
+  MediaWikiContent,
+  MediaWikiLink,
+  MediaWikiText,
+  MediaWikiTOC,
+} from "../../../../utils/mediawiki";
+import NewsFooterTransformer from "../footerTransformer";
+
+describe("NewsFooterTransformer", () => {
+  it("should insert the separator in front of social media discussion section", () => {
+    const originalContent: MediaWikiContent[] = [
+      new MediaWikiTOC(),
+      new MediaWikiBreak(),
+      new MediaWikiLink("test", "test"),
+      new MediaWikiBreak(),
+      new MediaWikiText("test", { bold: true }),
+      new MediaWikiBreak(),
+      new MediaWikiText("You can also discuss this update on our"),
+      new MediaWikiBreak(),
+      new MediaWikiText("Mods test, test and test", { bold: true }),
+      new MediaWikiBreak(),
+      new MediaWikiText("The Old School Team.", { italics: true }),
+    ];
+    const transformed = new NewsFooterTransformer().transform(originalContent);
+    expect(
+      new MediaWikiBuilder().addContents(transformed).build()
+    ).toMatchSnapshot();
+  });
+
+  it("should insert the separator in front of oldschool team section", () => {
+    const originalContent: MediaWikiContent[] = [
+      new MediaWikiTOC(),
+      new MediaWikiBreak(),
+      new MediaWikiLink("test", "test"),
+      new MediaWikiBreak(),
+      new MediaWikiText("test", { bold: true }),
+      new MediaWikiBreak(),
+      new MediaWikiText("The Old School Team.", { italics: true }),
+    ];
+    const transformed = new NewsFooterTransformer().transform(originalContent);
+    expect(
+      new MediaWikiBuilder().addContents(transformed).build()
+    ).toMatchSnapshot();
+  });
+});

--- a/src/scrapers/news/transformers/footerTransformer.ts
+++ b/src/scrapers/news/transformers/footerTransformer.ts
@@ -1,0 +1,31 @@
+import {
+  MediaWikiBreak,
+  MediaWikiContent,
+  MediaWikiText,
+  MediaWikiTransformer,
+} from "../../../utils/mediawiki";
+import MediaWikiSeparator from "../../../utils/mediawiki/contents/separator";
+
+class NewsFooterTransformer extends MediaWikiTransformer {
+  transform(content: MediaWikiContent[]): MediaWikiContent[] {
+    const footerStartContent = content.filter((content) => {
+      return (
+        content instanceof MediaWikiText &&
+        (content.value.startsWith("You can also discuss") ||
+          content.value.startsWith("The Old School Team"))
+      );
+    });
+    const footerStart = footerStartContent?.[0];
+    if (footerStart) {
+      const index = content.findIndex((content) => content == footerStart);
+      if (index) {
+        content.splice(index, 0, new MediaWikiSeparator());
+        content.splice(index + 1, 0, new MediaWikiBreak());
+        content.splice(index + 2, 0, new MediaWikiBreak());
+      }
+    }
+    return content;
+  }
+}
+
+export default NewsFooterTransformer;

--- a/src/scrapers/news/transformers/index.ts
+++ b/src/scrapers/news/transformers/index.ts
@@ -1,0 +1,1 @@
+export { default as NewsFooterTransformer } from "./footerTransformer";

--- a/src/utils/mediawiki/builder.ts
+++ b/src/utils/mediawiki/builder.ts
@@ -1,13 +1,19 @@
 import MediaWikiContent from "./content";
+import MediaWikiTransformer from "./transformer";
 
 class MediaWikiBuilder {
   content: MediaWikiContent[];
+  transformers: MediaWikiTransformer[];
 
   constructor() {
     this.content = [];
+    this.transformers = [];
   }
 
   build() {
+    this.transformers.forEach((transformer) => {
+      this.content = transformer.transform(this.content);
+    });
     const final =
       this.content?.reduce(
         (value, content) => (content ? value + "" + content.build() : value),
@@ -16,14 +22,21 @@ class MediaWikiBuilder {
     return final;
   }
 
-  addContent(content: MediaWikiContent) {
+  addContent(content: MediaWikiContent): MediaWikiBuilder {
     if (content !== null) {
       this.content.push(content);
     }
+    return this;
   }
 
-  addContents(contents: MediaWikiContent[]) {
+  addContents(contents: MediaWikiContent[]): MediaWikiBuilder {
     this.content = this.content.concat(contents);
+    return this;
+  }
+
+  addTransformer(transformer: MediaWikiTransformer): MediaWikiBuilder {
+    this.transformers.push(transformer);
+    return this;
   }
 }
 

--- a/src/utils/mediawiki/contents/__tests__/link.test.ts
+++ b/src/utils/mediawiki/contents/__tests__/link.test.ts
@@ -1,0 +1,13 @@
+import MediaWikiLink from "../link";
+
+describe("MediaWikiBreak", () => {
+  it("should build correctly with a label", () => {
+    const result = new MediaWikiLink("TestPage", "Label");
+    expect(result.build()).toBe("[[TestPage|Label]]");
+  });
+
+  it("should build correctly without a label", () => {
+    const result = new MediaWikiLink("TestPage");
+    expect(result.build()).toBe("[[TestPage]]");
+  });
+});

--- a/src/utils/mediawiki/contents/link.ts
+++ b/src/utils/mediawiki/contents/link.ts
@@ -1,10 +1,10 @@
 import MediaWikiContent from "../content";
 
 class MediaWikiLink extends MediaWikiContent {
-  label: string;
+  label?: string;
   link: string;
 
-  constructor(label: string, link: string) {
+  constructor(link: string, label?: string) {
     super();
     this.label = label;
     this.link = link;

--- a/src/utils/mediawiki/index.ts
+++ b/src/utils/mediawiki/index.ts
@@ -1,4 +1,5 @@
 export { default as MediaWikiBuilder } from "./builder";
 export { default as MediaWikiContent } from "./content";
+export { default as MediaWikiTransformer } from "./transformer";
 
 export * from "./contents";

--- a/src/utils/mediawiki/transformer.ts
+++ b/src/utils/mediawiki/transformer.ts
@@ -1,0 +1,7 @@
+import MediaWikiContent from "./content";
+
+abstract class MediaWikiTransformer {
+  abstract transform(content: MediaWikiContent[]): MediaWikiContent[];
+}
+
+export default MediaWikiTransformer;


### PR DESCRIPTION
**Description**

- Add support for "transformers" to dynamically change `MediaWikiContent` in `MediaWikiBuilder` before building final raw strings.
- Create a `NewsFooterTransformer` to insert a separator in the news post footer.