### PR TITLE
Fix a pollbox title bug causing the news scraper to fail

### DIFF
--- a/.changeset/six-tigers-live.md
+++ b/.changeset/six-tigers-live.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix a pollbox title bug causing the news scraper to fail

--- a/src/scrapers/news/sections/newsContent/nodes/div/pollBox.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/pollBox.ts
@@ -9,13 +9,14 @@ export const pollBoxParser: ContentNodeParser = (node) => {
     const divElement = node as HTMLElement;
     const childNodes = divElement.childNodes.filter(
       (childNode) =>
-        childNode instanceof HTMLElement &&
-        (childNode as HTMLElement).rawTagName === "p"
+        (childNode instanceof HTMLElement &&
+          (childNode as HTMLElement).rawTagName === "p") ||
+        (childNode as HTMLElement).rawTagName === "b"
     );
     const number = parseInt(
-      childNodes?.[0].textContent.replaceAll("Question ", "")
+      childNodes?.[0].textContent.replaceAll("Question ", "") ?? "1"
     );
-    const question = formatText(childNodes?.[1].textContent);
+    const question = formatText(childNodes?.[1]?.textContent);
     return new NewsPollTemplate(number, question).build();
   }
 };


### PR DESCRIPTION
**Description**
Fix a bug that caused the newspost scraper to fail due to a poll box title that is not in paragraph tag.

**Newspost**
https://secure.runescape.com/m=news/sailing-lock-in-poll?oldschool=1