### PR TITLE
[#22] Add support for transforming MediaWikiText into MediaWikiFile captions

### DIFF
--- a/.changeset/mighty-nails-brake.md
+++ b/.changeset/mighty-nails-brake.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Add support for transforming MediaWikiText into MediaWikiFile captions

--- a/src/scrapers/news/news.ts
+++ b/src/scrapers/news/news.ts
@@ -1,7 +1,10 @@
 import fs from "fs";
 
 import { newsContent, newsHeader } from "./sections";
-import { NewsFooterTransformer } from "./transformers";
+import {
+  NewsFooterTransformer,
+  NewsImageCaptionTransformer,
+} from "./transformers";
 import { formatFileName } from "../../utils/images";
 import { MediaWikiBuilder } from "../../utils/mediawiki";
 import { ScrapingService } from "../types";
@@ -31,6 +34,7 @@ const news: ScrapingService<MediaWikiBuilder> = {
         .addContents(
           await newsContent.format(results.content, page.url(), results.title)
         )
+        .addTransformer(new NewsImageCaptionTransformer())
         .addTransformer(new NewsFooterTransformer());
 
       console.info("Writing newspost results to file...");

--- a/src/scrapers/news/transformers/__tests__/__snapshots__/imageCaptionTransformer.test.ts.snap
+++ b/src/scrapers/news/transformers/__tests__/__snapshots__/imageCaptionTransformer.test.ts.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NewsImageCaptionTransformer should combine the adjacent MediaWikiFile, MediaWikiBreak and MediaWikiImage 1`] = `
+exports[`NewsImageCaptionTransformer should combine the adjacent MediaWikiFile, MediaWikiBreak and MediaWikiImage 1`] = `"[[File:image|''caption'']]"`;
+
+exports[`NewsImageCaptionTransformer should combine the adjacent MediaWikiFile, MediaWikiBreak and MediaWikiImage with surrounding content 1`] = `
 "__TOC__
 
 [[test|test]]

--- a/src/scrapers/news/transformers/__tests__/__snapshots__/imageCaptionTransformer.test.ts.snap
+++ b/src/scrapers/news/transformers/__tests__/__snapshots__/imageCaptionTransformer.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewsImageCaptionTransformer should combine the adjacent MediaWikiFile, MediaWikiBreak and MediaWikiImage 1`] = `
+"__TOC__
+
+[[test|test]]
+[[File:image|''caption'']]
+You can also discuss this update on our
+"
+`;
+
+exports[`NewsImageCaptionTransformer should not combine non-adjacent MediaWikiFile, MediaWikiBreak and MediaWikiText 1`] = `
+"__TOC__
+
+[[File:image]]
+test
+
+''testitalics''
+''The Old School Team.''"
+`;

--- a/src/scrapers/news/transformers/__tests__/imageCaptionTransformer.test.ts
+++ b/src/scrapers/news/transformers/__tests__/imageCaptionTransformer.test.ts
@@ -1,0 +1,54 @@
+import {
+  MediaWikiBreak,
+  MediaWikiBuilder,
+  MediaWikiContent,
+  MediaWikiFile,
+  MediaWikiLink,
+  MediaWikiText,
+  MediaWikiTOC,
+} from "../../../../utils/mediawiki";
+import NewsImageCaptionTransformer from "../imageCaptionTransformer";
+
+describe("NewsImageCaptionTransformer", () => {
+  it("should combine the adjacent MediaWikiFile, MediaWikiBreak and MediaWikiImage", () => {
+    const originalContent: MediaWikiContent[] = [
+      new MediaWikiTOC(),
+      new MediaWikiBreak(),
+      new MediaWikiLink("test", "test"),
+      new MediaWikiBreak(),
+      new MediaWikiFile("image"),
+      new MediaWikiBreak(),
+      new MediaWikiText("caption", { italics: true }),
+      new MediaWikiBreak(),
+      new MediaWikiText("You can also discuss this update on our"),
+      new MediaWikiBreak(),
+    ];
+    const transformed = new NewsImageCaptionTransformer().transform(
+      originalContent
+    );
+    expect(
+      new MediaWikiBuilder().addContents(transformed).build()
+    ).toMatchSnapshot();
+  });
+
+  it("should not combine non-adjacent MediaWikiFile, MediaWikiBreak and MediaWikiText", () => {
+    const originalContent: MediaWikiContent[] = [
+      new MediaWikiTOC(),
+      new MediaWikiBreak(),
+      new MediaWikiFile("image"),
+      new MediaWikiBreak(),
+      new MediaWikiText("test"),
+      new MediaWikiBreak(),
+      new MediaWikiBreak(),
+      new MediaWikiText("testitalics", { italics: true }),
+      new MediaWikiBreak(),
+      new MediaWikiText("The Old School Team.", { italics: true }),
+    ];
+    const transformed = new NewsImageCaptionTransformer().transform(
+      originalContent
+    );
+    expect(
+      new MediaWikiBuilder().addContents(transformed).build()
+    ).toMatchSnapshot();
+  });
+});

--- a/src/scrapers/news/transformers/__tests__/imageCaptionTransformer.test.ts
+++ b/src/scrapers/news/transformers/__tests__/imageCaptionTransformer.test.ts
@@ -12,6 +12,20 @@ import NewsImageCaptionTransformer from "../imageCaptionTransformer";
 describe("NewsImageCaptionTransformer", () => {
   it("should combine the adjacent MediaWikiFile, MediaWikiBreak and MediaWikiImage", () => {
     const originalContent: MediaWikiContent[] = [
+      new MediaWikiFile("image"),
+      new MediaWikiBreak(),
+      new MediaWikiText("caption", { italics: true }),
+    ];
+    const transformed = new NewsImageCaptionTransformer().transform(
+      originalContent
+    );
+    expect(
+      new MediaWikiBuilder().addContents(transformed).build()
+    ).toMatchSnapshot();
+  });
+
+  it("should combine the adjacent MediaWikiFile, MediaWikiBreak and MediaWikiImage with surrounding content", () => {
+    const originalContent: MediaWikiContent[] = [
       new MediaWikiTOC(),
       new MediaWikiBreak(),
       new MediaWikiLink("test", "test"),

--- a/src/scrapers/news/transformers/imageCaptionTransformer.ts
+++ b/src/scrapers/news/transformers/imageCaptionTransformer.ts
@@ -1,0 +1,43 @@
+import {
+  MediaWikiBreak,
+  MediaWikiContent,
+  MediaWikiFile,
+  MediaWikiText,
+  MediaWikiTransformer,
+} from "../../../utils/mediawiki";
+
+class NewsImageCaptionTransformer extends MediaWikiTransformer {
+  transform(content: MediaWikiContent[]): MediaWikiContent[] {
+    if (content.length < 4) {
+      return content;
+    }
+    const transformedContent = [];
+    for (let index = 0; index < content.length; index++) {
+      const current = content[index];
+      if (current instanceof MediaWikiFile && index < content.length - 2) {
+        const first = content[index + 1];
+        const second = content[index + 2];
+        if (
+          first instanceof MediaWikiBreak &&
+          second instanceof MediaWikiText &&
+          second.styling?.italics
+        ) {
+          transformedContent.push(
+            new MediaWikiFile(current.fileName, {
+              ...current.options,
+              caption: second,
+            })
+          );
+          index += 2;
+        } else {
+          transformedContent.push(current);
+        }
+      } else {
+        transformedContent.push(current);
+      }
+    }
+    return transformedContent;
+  }
+}
+
+export default NewsImageCaptionTransformer;

--- a/src/scrapers/news/transformers/imageCaptionTransformer.ts
+++ b/src/scrapers/news/transformers/imageCaptionTransformer.ts
@@ -8,7 +8,7 @@ import {
 
 class NewsImageCaptionTransformer extends MediaWikiTransformer {
   transform(content: MediaWikiContent[]): MediaWikiContent[] {
-    if (content.length < 4) {
+    if (content.length < 3) {
       return content;
     }
     const transformedContent = [];

--- a/src/scrapers/news/transformers/index.ts
+++ b/src/scrapers/news/transformers/index.ts
@@ -1,1 +1,2 @@
 export { default as NewsFooterTransformer } from "./footerTransformer";
+export { default as NewsImageCaptionTransformer } from "./imageCaptionTransformer";

--- a/src/utils/mediawiki/contents/file.ts
+++ b/src/utils/mediawiki/contents/file.ts
@@ -1,6 +1,8 @@
+import MediaWikiText from "./text";
 import MediaWikiContent from "../content";
 
 type MediaWikiFileOptions = {
+  caption?: MediaWikiText;
   format?: "frameless" | "frame" | "thumb";
   resizing?: {
     width?: number;
@@ -30,8 +32,14 @@ class MediaWikiFile extends MediaWikiContent {
 
   build() {
     let options = "";
-    const { format, resizing, horizontalAlignment, verticalAlignment, link } =
-      this.options;
+    const {
+      caption,
+      format,
+      resizing,
+      horizontalAlignment,
+      verticalAlignment,
+      link,
+    } = this.options ?? {};
     if (format) {
       options += `|${format}`;
     }
@@ -47,6 +55,9 @@ class MediaWikiFile extends MediaWikiContent {
     }
     if (verticalAlignment) {
       options += `|${verticalAlignment}`;
+    }
+    if (caption) {
+      options += `|${caption.build()}`;
     }
     if (link) {
       options += `|link=${link}`;

--- a/src/utils/mediawiki/contents/index.ts
+++ b/src/utils/mediawiki/contents/index.ts
@@ -6,6 +6,7 @@ export { default as MediaWikiHeader } from "./header";
 export { default as MediaWikiHTML } from "./html";
 export { default as MediaWikiLink } from "./link";
 export { default as MediaWikiListItem } from "./listItem";
+export { default as MediaWikiSeparator } from "./separator";
 export { default as MediaWikiTable } from "./table";
 export { default as MediaWikiTemplate } from "./template";
 export { default as MediaWikiText } from "./text";


### PR DESCRIPTION
**Description**
Transform italicized text directly under a file into the file's caption.