### PR TITLE
[#43] Add support for a NewsPoll template with no question number

### DIFF
--- a/.changeset/sour-birds-rest.md
+++ b/.changeset/sour-birds-rest.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Add support for a NewsPoll template with only a question

--- a/src/scrapers/news/sections/newsContent/nodes/div/pollBox.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/pollBox.ts
@@ -13,10 +13,16 @@ export const pollBoxParser: ContentNodeParser = (node) => {
           (childNode as HTMLElement).rawTagName === "p") ||
         (childNode as HTMLElement).rawTagName === "b"
     );
-    const number = childNodes?.[0]?.textContent?.replaceAll(/[^0-9]+/g, "");
-    const parsedNumber = parseInt(number ? number : "1");
-    const question = formatText(childNodes?.[1]?.textContent);
-    return new NewsPollTemplate(parsedNumber, question).build();
+    let parsedNumber;
+    let question = "";
+    if (childNodes?.length > 1) {
+      const number = childNodes?.[0]?.textContent?.replaceAll(/[^0-9]+/g, "");
+      parsedNumber = parseInt(number ? number : "1");
+      question = formatText(childNodes?.[1]?.textContent);
+    } else {
+      question = formatText(childNodes?.[0]?.textContent);
+    }
+    return new NewsPollTemplate(question, parsedNumber).build();
   }
 };
 

--- a/src/utils/mediawiki/contents/templates/__tests__/__snapshots__/newsPoll.test.ts.snap
+++ b/src/utils/mediawiki/contents/templates/__tests__/__snapshots__/newsPoll.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewsPollTemplate it should render with a number and question 1`] = `
+MediaWikiTemplate {
+  "name": "News Poll",
+  "params": Array [
+    Object {
+      "key": "",
+      "value": "5",
+    },
+    Object {
+      "key": "",
+      "value": "test?",
+    },
+  ],
+}
+`;
+
+exports[`NewsPollTemplate it should render with only a question 1`] = `
+MediaWikiTemplate {
+  "name": "News Poll",
+  "params": Array [
+    Object {
+      "key": "qtext",
+      "value": "test?",
+    },
+  ],
+}
+`;

--- a/src/utils/mediawiki/contents/templates/__tests__/newsPoll.test.ts
+++ b/src/utils/mediawiki/contents/templates/__tests__/newsPoll.test.ts
@@ -1,0 +1,11 @@
+import NewsPollTemplate from "../newsPoll";
+
+describe("NewsPollTemplate", () => {
+  test("it should render with a number and question", () => {
+    expect(new NewsPollTemplate("test?", 5).build()).toMatchSnapshot();
+  });
+
+  test("it should render with only a question", () => {
+    expect(new NewsPollTemplate("test?").build()).toMatchSnapshot();
+  });
+});

--- a/src/utils/mediawiki/contents/templates/newsPoll.ts
+++ b/src/utils/mediawiki/contents/templates/newsPoll.ts
@@ -2,10 +2,10 @@ import { Template } from "./types";
 import MediaWikiTemplate from "../template";
 
 class NewsPollTemplate extends Template {
-  number: number;
+  number?: number;
   question: string;
 
-  constructor(number: number, question: string) {
+  constructor(question: string, number?: number) {
     super("News Poll");
     this.number = number;
     this.question = question;
@@ -13,8 +13,10 @@ class NewsPollTemplate extends Template {
 
   build() {
     const newsPollTemplate = new MediaWikiTemplate(this.name);
-    newsPollTemplate.add("", this.number?.toString() ?? "1");
-    newsPollTemplate.add("", this.question);
+    if (this.number) {
+      newsPollTemplate.add("", this.number?.toString());
+    }
+    newsPollTemplate.add(this.number ? "" : "qtext", this.question);
     return newsPollTemplate;
   }
 }

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -3,9 +3,9 @@
  * @param text
  * @returns
  */
-export const formatText = (text: string) =>
+export const formatText = (text?: string) =>
   text
-    .replaceAll("&amp;", "&")
-    .replaceAll("\t", "")
-    .replaceAll("\n", "")
-    .replaceAll("\r", "");
+    ?.replaceAll("&amp;", "&")
+    ?.replaceAll("\t", "")
+    ?.replaceAll("\n", "")
+    ?.replaceAll("\r", "");


### PR DESCRIPTION
**Description**
This PR adds support for only passing a question, with no number, to `NewsPollTemplate`.

Solves #43 