### PR TITLE
[#46] Fix MediaWikiHeader spacing and bullet list spacing

### DIFF
--- a/.changeset/nervous-ways-arrive.md
+++ b/.changeset/nervous-ways-arrive.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix sub-bullet list spacing

--- a/.changeset/shiny-books-heal.md
+++ b/.changeset/shiny-books-heal.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix spacing around MediaWikiHeader's

--- a/src/scrapers/news/news.ts
+++ b/src/scrapers/news/news.ts
@@ -36,9 +36,9 @@ const news: ScrapingService<MediaWikiBuilder> = {
         .addContents(
           await newsContent.format(results.content, page.url(), results.title)
         )
+        .addTransformer(new NewsHeaderTransformer())
         .addTransformer(new NewsBreakTransformer())
         .addTransformer(new NewsImageCaptionTransformer())
-        .addTransformer(new NewsHeaderTransformer())
         .addTransformer(new NewsFooterTransformer());
 
       console.info("Writing newspost results to file...");

--- a/src/scrapers/news/sections/newsContent/nodes/list.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/list.ts
@@ -23,7 +23,9 @@ export const listParser: ContentNodeParser = (node, options) => {
         return textParser(childNode, { ...options, ordered, level });
       })
       .flat();
-    content.push(new MediaWikiBreak());
+    if (!options.level) {
+      content.push(new MediaWikiBreak());
+    }
     return content;
   }
 };

--- a/src/scrapers/news/transformers/__tests__/__snapshots__/breakTransformer.test.ts.snap
+++ b/src/scrapers/news/transformers/__tests__/__snapshots__/breakTransformer.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewsBreakTransformer should combine three lines breaks to one 1`] = `
+"__TOC__
+
+''The Old School Team.''"
+`;
+
+exports[`NewsBreakTransformer should remove the line breaks after a header 1`] = `
+"__TOC__
+
+==Test==
+''The Old School Team.''"
+`;

--- a/src/scrapers/news/transformers/__tests__/breakTransformer.test.ts
+++ b/src/scrapers/news/transformers/__tests__/breakTransformer.test.ts
@@ -2,6 +2,7 @@ import {
   MediaWikiBreak,
   MediaWikiBuilder,
   MediaWikiContent,
+  MediaWikiHeader,
   MediaWikiText,
   MediaWikiTOC,
 } from "../../../../utils/mediawiki";
@@ -12,6 +13,21 @@ describe("NewsBreakTransformer", () => {
     const originalContent: MediaWikiContent[] = [
       new MediaWikiTOC(),
       new MediaWikiBreak(),
+      new MediaWikiBreak(),
+      new MediaWikiBreak(),
+      new MediaWikiText("The Old School Team.", { italics: true }),
+    ];
+    const transformed = new NewsBreakTransformer().transform(originalContent);
+    expect(
+      new MediaWikiBuilder().addContents(transformed).build()
+    ).toMatchSnapshot();
+  });
+
+  it("should remove the line breaks after a header", () => {
+    const originalContent: MediaWikiContent[] = [
+      new MediaWikiTOC(),
+      new MediaWikiBreak(),
+      new MediaWikiHeader("Test", 2),
       new MediaWikiBreak(),
       new MediaWikiBreak(),
       new MediaWikiText("The Old School Team.", { italics: true }),

--- a/src/scrapers/news/transformers/breakTransformer.ts
+++ b/src/scrapers/news/transformers/breakTransformer.ts
@@ -1,6 +1,7 @@
 import {
   MediaWikiBreak,
   MediaWikiContent,
+  MediaWikiHeader,
   MediaWikiTransformer,
 } from "../../../utils/mediawiki";
 
@@ -21,6 +22,8 @@ class NewsBreakTransformer extends MediaWikiTransformer {
           after instanceof MediaWikiBreak
         ) {
           index++;
+        } else if (before instanceof MediaWikiHeader) {
+          continue;
         } else {
           transformedContent.push(current);
         }


### PR DESCRIPTION
**Description**
Resolves #46. This PR resolves spacing issues around the resulting `MediaWikiHeader`'s in the news post scraper. This PR also resolves the extra line placed between sub-bullet lists.