### PR TITLE
[#50] Add support for Dev Blogs news post category

### DIFF
--- a/.changeset/plenty-rockets-accept.md
+++ b/.changeset/plenty-rockets-accept.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Add support for the "Dev Blogs" news post category

--- a/src/scrapers/news/sections/newsHeader/newsHeader.utils.ts
+++ b/src/scrapers/news/sections/newsHeader/newsHeader.utils.ts
@@ -27,6 +27,8 @@ const updateCategories: { [key: string]: NewsCategory } = {
   "Competitions": "competitions",
   "Developer Blogs": "devblog",
   "Developer Blog": "devblog",
+  "Dev Blog": "devblog",
+  "Dev Blogs": "devblog",
   "Event updates": "event",
   "Event update": "event",
   "Game updates": "game",


### PR DESCRIPTION
**Description**
Add support for the "Dev Blogs" news post category.
Resolves #50 
