### PR TITLE
[#59] Add support for image button links

### DIFF
--- a/.changeset/sour-colts-beam.md
+++ b/.changeset/sour-colts-beam.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Support image buttons including a link

--- a/src/scrapers/news/sections/newsContent/nodes/image.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/image.ts
@@ -13,7 +13,10 @@ import { ContentNodeParser } from "../types";
 
 const ignoredClasses = ["demo cursor"];
 
-export const imageParser: ContentNodeParser = (node, { title, center }) => {
+export const imageParser: ContentNodeParser = (
+  node,
+  { title, center, link }
+) => {
   if (node instanceof HTMLElement) {
     const image = node as HTMLElement;
     const imageLink = image.attributes.src;
@@ -41,6 +44,10 @@ export const imageParser: ContentNodeParser = (node, { title, center }) => {
       new MediaWikiFile(`${imageName}.${imageExtension}`, {
         resizing: { width: dimensions.width > 600 ? 600 : dimensions.width },
         horizontalAlignment: center ? "center" : undefined,
+        link:
+          imageLink.includes("Button.png") && link
+            ? (link as string)
+            : undefined,
       }),
       new MediaWikiBreak(),
     ];


### PR DESCRIPTION
**Description**
Resolves #59. Add supporting for including a `link` in images that are titled `Button.png`. This is currently the only way to distinguish clickable buttons in a news post since all news post images have links.