### PR TITLE
[#68] Support text parsing in MediaWikiHeader

### DIFF
--- a/.changeset/slimy-dolls-hear.md
+++ b/.changeset/slimy-dolls-hear.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Add children support to MediaWikiContent

--- a/.changeset/weak-suns-shop.md
+++ b/.changeset/weak-suns-shop.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Support text parsing in MediaWikiHeader

--- a/src/scrapers/news/sections/newsContent/nodes/font.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/font.ts
@@ -1,12 +1,12 @@
 import { HTMLElement } from "node-html-parser";
 
+import textParser from "./text";
 import { MediaWikiHeader } from "../../../../../utils/mediawiki";
 import { ContentNodeParser } from "../types";
 
 export const fontParser: ContentNodeParser = (node) => {
   if (node instanceof HTMLElement) {
-    const element = node as HTMLElement;
-    return new MediaWikiHeader(element.rawText, 2);
+    return new MediaWikiHeader(textParser(node), 2);
   }
 };
 

--- a/src/utils/mediawiki/content.ts
+++ b/src/utils/mediawiki/content.ts
@@ -1,5 +1,25 @@
 abstract class MediaWikiContent {
+  children?: MediaWikiContent | MediaWikiContent[];
+
+  constructor(children?: MediaWikiContent | MediaWikiContent[]) {
+    this.children = children;
+  }
+
   abstract build(): string;
+
+  buildChildren(): string {
+    if (this.children && Array.isArray(this.children)) {
+      return (
+        this.children?.reduce(
+          (value, content) => (content ? value + "" + content.build() : value),
+          ""
+        ) ?? ""
+      );
+    } else if (this.children && this.children instanceof MediaWikiContent) {
+      return this.children.build();
+    }
+    return "";
+  }
 }
 
 export default MediaWikiContent;

--- a/src/utils/mediawiki/contents/__tests__/header.test.ts
+++ b/src/utils/mediawiki/contents/__tests__/header.test.ts
@@ -1,8 +1,29 @@
 import MediaWikiHeader from "../header";
+import MediaWikiText from "../text";
 
 describe("MediaWikiHeader", () => {
-  test("it should build correctly", () => {
+  test("it should build correctly with a string value", () => {
     const header = new MediaWikiHeader("Test", 2);
     expect(header.build()).toBe("==Test==");
+  });
+
+  test("it should build correctly with a non-array MediaWikiContent", () => {
+    const header = new MediaWikiHeader(
+      new MediaWikiText("Test", { italics: true }),
+      2
+    );
+    expect(header.build()).toBe("==''Test''==");
+  });
+
+  test("it should build correctly with an array of MediaWikiContent", () => {
+    const header = new MediaWikiHeader(
+      [
+        new MediaWikiText("Start "),
+        new MediaWikiText("Test", { italics: true }),
+        new MediaWikiText(" End"),
+      ],
+      3
+    );
+    expect(header.build()).toBe("===Start ''Test'' End===");
   });
 });

--- a/src/utils/mediawiki/contents/header.ts
+++ b/src/utils/mediawiki/contents/header.ts
@@ -4,16 +4,27 @@ class MediaWikiHeader extends MediaWikiContent {
   value: string;
   level: number;
 
-  constructor(value: string, level: number) {
-    super();
-    this.value = value;
+  constructor(
+    value: string | MediaWikiContent | MediaWikiContent[],
+    level: number
+  ) {
+    super(
+      Array.isArray(value) || value instanceof MediaWikiContent
+        ? value
+        : undefined
+    );
+    this.value = typeof value === "string" ? (value as string) : undefined;
     this.level = level;
   }
 
   build() {
-    return `${"=".repeat(this.level)}${this.value.trim()}${"=".repeat(
-      this.level
-    )}`;
+    let parsedValue;
+    if (this.children) {
+      parsedValue = this.buildChildren();
+    } else if (this.value) {
+      parsedValue = this.value.trim();
+    }
+    return `${"=".repeat(this.level)}${parsedValue}${"=".repeat(this.level)}`;
   }
 }
 

--- a/src/utils/mediawiki/contents/html.ts
+++ b/src/utils/mediawiki/contents/html.ts
@@ -2,7 +2,6 @@ import MediaWikiContent from "../content";
 
 class MediaWikiHTML extends MediaWikiContent {
   attributes?: { [key: string]: string };
-  children: MediaWikiContent[];
   tag: string;
 
   constructor(
@@ -10,9 +9,8 @@ class MediaWikiHTML extends MediaWikiContent {
     children: MediaWikiContent[],
     attributes?: { [key: string]: string }
   ) {
-    super();
+    super(children);
     this.tag = tag;
-    this.children = children;
     this.attributes = attributes;
   }
 
@@ -23,10 +21,7 @@ class MediaWikiHTML extends MediaWikiContent {
             (key) => ` ${key}=\"${this.attributes[key]}\"`
           )
         : ""
-    }>\n${this.children.reduce(
-      (value, content) => (value += content.build()),
-      ""
-    )}\n</${this.tag}>\n`;
+    }>\n${this.buildChildren()}\n</${this.tag}>\n`;
   }
 }
 

--- a/src/utils/mediawiki/contents/templates/__tests__/__snapshots__/listen.test.ts.snap
+++ b/src/utils/mediawiki/contents/templates/__tests__/__snapshots__/listen.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`ListenTemplate it should render with only a file 1`] = `
 MediaWikiTemplate {
+  "children": undefined,
   "name": "Listen",
   "params": Array [
     Object {
@@ -14,6 +15,7 @@ MediaWikiTemplate {
 
 exports[`ListenTemplate it should render with options: {"align":"left","title":"test title"} 1`] = `
 MediaWikiTemplate {
+  "children": undefined,
   "name": "Listen",
   "params": Array [
     Object {
@@ -34,6 +36,7 @@ MediaWikiTemplate {
 
 exports[`ListenTemplate it should render with options: {"align":"left"} 1`] = `
 MediaWikiTemplate {
+  "children": undefined,
   "name": "Listen",
   "params": Array [
     Object {
@@ -50,6 +53,7 @@ MediaWikiTemplate {
 
 exports[`ListenTemplate it should render with options: {"title":"test title"} 1`] = `
 MediaWikiTemplate {
+  "children": undefined,
   "name": "Listen",
   "params": Array [
     Object {

--- a/src/utils/mediawiki/contents/templates/__tests__/__snapshots__/newsPoll.test.ts.snap
+++ b/src/utils/mediawiki/contents/templates/__tests__/__snapshots__/newsPoll.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`NewsPollTemplate it should render with a number and question 1`] = `
 MediaWikiTemplate {
+  "children": undefined,
   "name": "News Poll",
   "params": Array [
     Object {
@@ -18,6 +19,7 @@ MediaWikiTemplate {
 
 exports[`NewsPollTemplate it should render with only a question 1`] = `
 MediaWikiTemplate {
+  "children": undefined,
   "name": "News Poll",
   "params": Array [
     Object {


### PR DESCRIPTION
**Description**

- Add children support to `MediaWikiContent`
- Support text parsing in `MediaWikiHeader` by using `MediaWikiContent` children