### PR TITLE
[#79] Add support for embedded videos

### DIFF
--- a/.changeset/thirty-months-check.md
+++ b/.changeset/thirty-months-check.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Add support for embedded videos

--- a/src/scrapers/news/sections/newsContent/newsContent.ts
+++ b/src/scrapers/news/sections/newsContent/newsContent.ts
@@ -26,12 +26,12 @@ const newsContent: NewsSection = {
   format: async (html, url, title) => {
     const contentRoot = parse(html);
 
-    const images = contentRoot.querySelectorAll("img");
+    const images = contentRoot.querySelectorAll("img, video > source");
     let downloadedImages = 0;
     const downloadQueue = [];
     for (let index = 0; index < images.length; index++) {
       const image = images[index];
-      const imageLink = image.attributes.src;
+      const imageLink = image.attributes.src ?? image.attributes.href;
 
       if (
         imageLink.endsWith("hr.png") ||

--- a/src/scrapers/news/sections/newsContent/nodes/image.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/image.ts
@@ -12,14 +12,15 @@ import { ContentContext } from "../newsContent";
 import { ContentNodeParser } from "../types";
 
 const ignoredClasses = ["demo cursor"];
+const imageExtensions = ["png", "jpg", "gif"];
 
 export const imageParser: ContentNodeParser = (
   node,
-  { title, center, link }
+  { title, center, link, width }
 ) => {
   if (node instanceof HTMLElement) {
     const image = node as HTMLElement;
-    const imageLink = image.attributes.src;
+    const imageLink = image.attributes.src ?? image.attributes.href;
 
     if (
       imageLink.endsWith("hr.png") ||
@@ -38,7 +39,7 @@ export const imageParser: ContentNodeParser = (
     const imageExtension = getFileExtension(imageLink);
     const imagePath = `${imageDirectory}/${imageName}.${imageExtension}`;
     let dimensions;
-    if (fs.existsSync(imagePath)) {
+    if (imageExtensions.includes(imageExtension) && fs.existsSync(imagePath)) {
       dimensions = sizeOf(`${imageDirectory}/${imageName}.${imageExtension}`);
     }
 
@@ -46,7 +47,8 @@ export const imageParser: ContentNodeParser = (
       new MediaWikiFile(`${imageName}.${imageExtension}`, {
         resizing: {
           width:
-            dimensions?.width > 600 || !dimensions ? 600 : dimensions.width,
+            (width as number) ??
+            (dimensions?.width > 600 || !dimensions ? 600 : dimensions.width),
         },
         horizontalAlignment: center ? "center" : undefined,
         link:

--- a/src/scrapers/news/sections/newsContent/nodes/parser.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/parser.ts
@@ -14,6 +14,7 @@ import listItemParser from "./listItem";
 import paragraphParser from "./paragraph";
 import tableParser from "./table";
 import underlineParser from "./underline";
+import videoParser from "./video";
 import { MediaWikiComment } from "../../../../../utils/mediawiki";
 import { ContentNodeParser } from "../types";
 
@@ -37,6 +38,7 @@ const nodeParserMap: { [key: string]: ContentNodeParser } = {
   table: tableParser,
   u: underlineParser,
   ul: listParser,
+  video: videoParser,
 };
 
 const nodeParser: ContentNodeParser = (node, options) => {

--- a/src/scrapers/news/sections/newsContent/nodes/video.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/video.ts
@@ -1,0 +1,21 @@
+import { HTMLElement } from "node-html-parser";
+
+import imageParser from "./image";
+import { MediaWikiComment } from "../../../../../utils/mediawiki";
+import { ContentNodeParser } from "../types";
+
+export const videoParser: ContentNodeParser = (node, { title }) => {
+  const firstNode = node.childNodes.filter(
+    (node) => node instanceof HTMLElement
+  )?.[0];
+  if (node instanceof HTMLElement && firstNode instanceof HTMLElement) {
+    const source = firstNode as HTMLElement;
+    const width = node.attributes.width
+      ? parseInt(node.attributes.width)
+      : undefined;
+    return imageParser(source, { title, width });
+  }
+  return new MediaWikiComment("Invalid video node");
+};
+
+export default videoParser;


### PR DESCRIPTION
**Description**

- Add support for parsing `video` tags
- Add support for downloading `video` tags as a part of the news post file output.