### PR TITLE
[#78] Add support for parsing header levels

### DIFF
--- a/.changeset/tough-lamps-judge.md
+++ b/.changeset/tough-lamps-judge.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Add support for parsing different header levels

--- a/src/scrapers/news/sections/newsContent/nodes/font.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/font.ts
@@ -4,9 +4,23 @@ import textParser from "./text";
 import { MediaWikiHeader } from "../../../../../utils/mediawiki";
 import { ContentNodeParser } from "../types";
 
+const fontSizeHeaders: { [key: number]: number } = {
+  22: 2,
+  18: 3,
+};
+
+const REGEX_FONT_SIZE = /font-size:[ ]*([0-9]*)[a-z]*;/gm;
+
 export const fontParser: ContentNodeParser = (node) => {
   if (node instanceof HTMLElement) {
-    return new MediaWikiHeader(textParser(node), 2);
+    const fontSizeRaw = node.attributes.style.match(REGEX_FONT_SIZE)?.[0];
+    const fontSize = fontSizeRaw
+      ? parseInt(fontSizeRaw.replaceAll(/[^\d]*/g, ""))
+      : undefined;
+    return new MediaWikiHeader(
+      textParser(node),
+      fontSizeHeaders[fontSize ?? 22]
+    );
   }
 };
 

--- a/src/utils/mediawiki/contents/header.ts
+++ b/src/utils/mediawiki/contents/header.ts
@@ -22,9 +22,11 @@ class MediaWikiHeader extends MediaWikiContent {
     if (this.children) {
       parsedValue = this.buildChildren();
     } else if (this.value) {
-      parsedValue = this.value.trim();
+      parsedValue = this.value;
     }
-    return `${"=".repeat(this.level)}${parsedValue}${"=".repeat(this.level)}`;
+    return `${"=".repeat(this.level)}${parsedValue.trim()}${"=".repeat(
+      this.level
+    )}`;
   }
 }
 


### PR DESCRIPTION
**Description**

- Add support for parsing header levels by the `font-style` attribute in the `font` tag.